### PR TITLE
Changed the implementation of second() and microsecond() to match the behaviour of DB2

### DIFF
--- a/db2fce--0.0.6.sql
+++ b/db2fce--0.0.6.sql
@@ -283,6 +283,12 @@ AS $$ SELECT lower($1); $$
 LANGUAGE SQL IMMUTABLE STRICT;
 COMMENT ON FUNCTION db2.lcase(text) IS 'lowercase';
 
+CREATE FUNCTION db2.strip(value text)
+RETURNS text
+AS $$ SELECT trim($1); $$
+LANGUAGE SQL IMMUTABLE STRICT;
+COMMENT ON FUNCTION db2.strip(text) IS 'Removes blanks from the beginning and end of a string. Alias for trim().';
+
 -- CHAR()/INTEGER()/INT()/DOUBLE()/DECIMAL()/DEC() functions (CASTs)
 
 CREATE FUNCTION db2.char(value text)

--- a/db2fce--0.0.6.sql
+++ b/db2fce--0.0.6.sql
@@ -446,6 +446,41 @@ AS $$ SELECT pg_catalog.round($1::numeric, $2); $$
 LANGUAGE SQL IMMUTABLE STRICT;
 COMMENT ON FUNCTION db2.round(double precision, integer) IS 'value rounded to ''scale''';
 
+-- DIGITS() function
+-- https://www.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/com.ibm.db2z10.doc.sqlref/src/tpc/db2z_bif_digits.dita
+
+-- Smallint input: return length = 5
+CREATE FUNCTION db2.digits(value smallint) RETURNS varchar(5) AS
+$func$
+    SELECT regexp_replace(to_char($1, repeat('0', 5)), '^[ +-]', '');
+$func$
+LANGUAGE SQL IMMUTABLE STRICT;
+
+-- Integer input: return length = 10
+CREATE FUNCTION db2.digits(value integer) RETURNS varchar(10) AS
+$func$
+    SELECT regexp_replace(to_char($1, repeat('0', 10)), '^[ +-]', '');
+$func$
+LANGUAGE SQL IMMUTABLE STRICT;
+
+-- Bigint input: return length = 19
+CREATE FUNCTION db2.digits(value bigint) RETURNS varchar(19) AS
+$func$
+    SELECT regexp_replace(to_char($1, repeat('0', 19)), '^[ +-]', '');
+$func$
+LANGUAGE SQL IMMUTABLE STRICT;
+
+-- Generic numeric implementation.
+-- On numeric(precision,scale) input, the length should depend on the precision of the argument.
+-- I haven't found a way to determine that. So the formatted number will be returned without leading zeroes.
+-- The result won't be compatible with DB2 if the value has less digits than its type.
+CREATE FUNCTION db2.digits(value numeric) RETURNS text as 
+$func$
+    SELECT regexp_replace($1::text, '[^0-9]', '', 'g');
+$func$
+LANGUAGE SQL IMMUTABLE STRICT;
+
+
 -- VALUE() function (alias for COALESCE())
 
 CREATE FUNCTION db2.value(variadic anyarray) 

--- a/db2fce--0.0.8.sql
+++ b/db2fce--0.0.8.sql
@@ -20,13 +20,13 @@ GRANT USAGE ON SCHEMA db2 TO PUBLIC;
 
 CREATE FUNCTION db2.microsecond(value timestamp)
 RETURNS integer
-AS $$ SELECT date_part('microsecond', $1)::integer; $$
+AS $$ SELECT date_part('microsecond', $1) - floor(date_part('second', $1)) * 1000000; $$
 LANGUAGE SQL IMMUTABLE STRICT;
 COMMENT ON FUNCTION db2.microsecond(timestamp) IS 'returns microsecond part of specified timestamp';
 
 CREATE FUNCTION db2.second(value timestamp)
 RETURNS integer
-AS $$ SELECT date_part('second', $1)::integer; $$
+AS $$ SELECT floor(date_part('second', $1)); $$
 LANGUAGE SQL IMMUTABLE STRICT;
 COMMENT ON FUNCTION db2.second(timestamp) IS 'returns second part of specified timestamp';
 


### PR DESCRIPTION
second() was rounding seconds instead of using floor()

microsecond() included the seconds as date_part('microsecond', timestamp) in PostgreSQL does.

Both were changed and tested with the DB2 counterparts.
