### PR TITLE
Proposed update to db2fce: Version 0.0.16 compatible with Postgres up to 18

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,13 @@
 db2fce News - History of user-visible changes
 Copyright (C) 2015-2022 credativ GmbH
 
+Version 0.0.16 - 2026-01-23
+
+* Removed NEGATOR from ^= operators for PG > 16 compatibility. (Balázs Bárány)
+
+This will lead to worse performance in queries using the ^= operator if the 
+optimizer negates the expression. 
+
 Version 0.0.15 - 2022-07-12
 
 * Removed array-based concatenation operator aliases

--- a/db2fce--0.0.15--0.0.16.sql
+++ b/db2fce--0.0.15--0.0.16.sql
@@ -1,8 +1,3 @@
-/* contrib/db2fce--0.0.15.sql */
-
--- complain if script is sourced in psql, rather than via CREATE EXTENSION
-\echo Use "CREATE EXTENSION db2fce" to load this file. \quit
-
 -- ^= operator (alias for <> and !=)
 
 -- We need to drop the old versions of the operator with the NEGATOR. Duplicate negators aren't supported anymore in Postgres.
@@ -549,5 +544,3 @@ CREATE OPERATOR db2.^= (
     JOIN = neqjoinsel
 );
 COMMENT ON OPERATOR db2.^= (anyrange, anyrange) IS 'not equal';
-
-RESET search_path;

--- a/db2fce--0.0.15--0.0.16.sql
+++ b/db2fce--0.0.15--0.0.16.sql
@@ -1,0 +1,553 @@
+/* contrib/db2fce--0.0.15.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION db2fce" to load this file. \quit
+
+-- ^= operator (alias for <> and !=)
+
+-- We need to drop the old versions of the operator with the NEGATOR. Duplicate negators aren't supported anymore in Postgres.
+-- Recreating the operators without negator means that the optimizer can't generate NOT() expressions for this operator anymore, 
+-- which can lead to suboptimal performance.
+
+DROP OPERATOR IF EXISTS db2.^= (anyarray, anyarray);
+DROP OPERATOR IF EXISTS db2.^= (anyenum, anyenum);
+DROP OPERATOR IF EXISTS db2.^= (anyrange, anyrange);
+DROP OPERATOR IF EXISTS db2.^= (bit, bit);
+DROP OPERATOR IF EXISTS db2.^= (bool, bool);
+DROP OPERATOR IF EXISTS db2.^= (bpchar, bpchar);
+DROP OPERATOR IF EXISTS db2.^= (bytea, bytea);
+DROP OPERATOR IF EXISTS db2.^= (char, char);
+DROP OPERATOR IF EXISTS db2.^= (circle, circle);
+DROP OPERATOR IF EXISTS db2.^= (date, date);
+DROP OPERATOR IF EXISTS db2.^= (date, timestamp);
+DROP OPERATOR IF EXISTS db2.^= (date, timestamptz);
+DROP OPERATOR IF EXISTS db2.^= (float4, float4);
+DROP OPERATOR IF EXISTS db2.^= (float4, float8);
+DROP OPERATOR IF EXISTS db2.^= (float8, float4);
+DROP OPERATOR IF EXISTS db2.^= (float8, float8);
+DROP OPERATOR IF EXISTS db2.^= (inet, inet);
+DROP OPERATOR IF EXISTS db2.^= (int2, int2);
+DROP OPERATOR IF EXISTS db2.^= (int2, int4);
+DROP OPERATOR IF EXISTS db2.^= (int2, int8);
+DROP OPERATOR IF EXISTS db2.^= (int4, int2);
+DROP OPERATOR IF EXISTS db2.^= (int4, int4);
+DROP OPERATOR IF EXISTS db2.^= (int4, int8);
+DROP OPERATOR IF EXISTS db2.^= (int8, int2);
+DROP OPERATOR IF EXISTS db2.^= (int8, int4);
+DROP OPERATOR IF EXISTS db2.^= (int8, int8);
+DROP OPERATOR IF EXISTS db2.^= (interval, interval);
+DROP OPERATOR IF EXISTS db2.^= (lseg, lseg);
+DROP OPERATOR IF EXISTS db2.^= (macaddr, macaddr);
+DROP OPERATOR IF EXISTS db2.^= (money, money);
+DROP OPERATOR IF EXISTS db2.^= (name, name);
+DROP OPERATOR IF EXISTS db2.^= (numeric, numeric);
+DROP OPERATOR IF EXISTS db2.^= (oid, oid);
+DROP OPERATOR IF EXISTS db2.^= (oidvector, oidvector);
+DROP OPERATOR IF EXISTS db2.^= (point, point);
+DROP OPERATOR IF EXISTS db2.^= (record, record);
+DROP OPERATOR IF EXISTS db2.^= (text, text);
+DROP OPERATOR IF EXISTS db2.^= (tid, tid);
+DROP OPERATOR IF EXISTS db2.^= (time, time);
+DROP OPERATOR IF EXISTS db2.^= (timestamp, date);
+DROP OPERATOR IF EXISTS db2.^= (timestamp, timestamp);
+DROP OPERATOR IF EXISTS db2.^= (timestamp, timestamptz);
+DROP OPERATOR IF EXISTS db2.^= (timestamptz, date);
+DROP OPERATOR IF EXISTS db2.^= (timestamptz, timestamp);
+DROP OPERATOR IF EXISTS db2.^= (timestamptz, timestamptz);
+DROP OPERATOR IF EXISTS db2.^= (timetz, timetz);
+DROP OPERATOR IF EXISTS db2.^= (tsquery, tsquery);
+DROP OPERATOR IF EXISTS db2.^= (tsvector, tsvector);
+DROP OPERATOR IF EXISTS db2.^= (uuid, uuid);
+DROP OPERATOR IF EXISTS db2.^= (varbit, varbit);
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.int48ne,
+    LEFTARG = integer,
+    RIGHTARG = bigint,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (integer, bigint) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.boolne,
+    LEFTARG = boolean,
+    RIGHTARG = boolean,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (boolean, boolean) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.tidne,
+    LEFTARG = tid,
+    RIGHTARG = tid,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (tid, tid) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.int8ne,
+    LEFTARG = bigint,
+    RIGHTARG = bigint,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (bigint, bigint) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.int84ne,
+    LEFTARG = bigint,
+    RIGHTARG = integer,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (bigint, integer) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.int4ne,
+    LEFTARG = integer,
+    RIGHTARG = integer,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (integer, integer) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.int2ne,
+    LEFTARG = smallint,
+    RIGHTARG = smallint,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (smallint, smallint) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.textne,
+    LEFTARG = text,
+    RIGHTARG = text,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (text, text) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.int24ne,
+    LEFTARG = smallint,
+    RIGHTARG = integer,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (smallint, integer) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.int42ne,
+    LEFTARG = integer,
+    RIGHTARG = smallint,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (integer, smallint) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.oidne,
+    LEFTARG = oid,
+    RIGHTARG = oid,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (oid, oid) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.float4ne,
+    LEFTARG = real,
+    RIGHTARG = real,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (real, real) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.namene,
+    LEFTARG = name,
+    RIGHTARG = name,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (name, name) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.oidvectorne,
+    LEFTARG = oidvector,
+    RIGHTARG = oidvector,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (oidvector, oidvector) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.float8ne,
+    LEFTARG = double precision,
+    RIGHTARG = double precision,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (double precision, double precision) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.point_ne,
+    LEFTARG = point,
+    RIGHTARG = point,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (point, point) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.cash_ne,
+    LEFTARG = money,
+    RIGHTARG = money,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (money, money) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.bpcharne,
+    LEFTARG = character,
+    RIGHTARG = character,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (character, character) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.array_ne,
+    LEFTARG = anyarray,
+    RIGHTARG = anyarray,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (anyarray, anyarray) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.date_ne,
+    LEFTARG = date,
+    RIGHTARG = date,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (date, date) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.time_ne,
+    LEFTARG = time without time zone,
+    RIGHTARG = time without time zone,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (time without time zone, time without time zone) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.float48ne,
+    LEFTARG = real,
+    RIGHTARG = double precision,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (real, double precision) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.float84ne,
+    LEFTARG = double precision,
+    RIGHTARG = real,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (double precision, real) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.network_ne,
+    LEFTARG = inet,
+    RIGHTARG = inet,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (inet, inet) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.macaddr_ne,
+    LEFTARG = macaddr,
+    RIGHTARG = macaddr,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (macaddr, macaddr) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.timestamptz_ne,
+    LEFTARG = timestamp with time zone,
+    RIGHTARG = timestamp with time zone,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (timestamp with time zone, timestamp with time zone) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.interval_ne,
+    LEFTARG = interval,
+    RIGHTARG = interval,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (interval, interval) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.circle_ne,
+    LEFTARG = circle,
+    RIGHTARG = circle,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (circle, circle) IS 'not equal by area';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.timetz_ne,
+    LEFTARG = time with time zone,
+    RIGHTARG = time with time zone,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (time with time zone, time with time zone) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.lseg_ne,
+    LEFTARG = lseg,
+    RIGHTARG = lseg,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (lseg, lseg) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.numeric_ne,
+    LEFTARG = numeric,
+    RIGHTARG = numeric,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (numeric, numeric) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.bitne,
+    LEFTARG = bit,
+    RIGHTARG = bit,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (bit, bit) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.varbitne,
+    LEFTARG = bit varying,
+    RIGHTARG = bit varying,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (bit varying, bit varying) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.int28ne,
+    LEFTARG = smallint,
+    RIGHTARG = bigint,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (smallint, bigint) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.int82ne,
+    LEFTARG = bigint,
+    RIGHTARG = smallint,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (bigint, smallint) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.byteane,
+    LEFTARG = bytea,
+    RIGHTARG = bytea,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (bytea, bytea) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.timestamp_ne,
+    LEFTARG = timestamp without time zone,
+    RIGHTARG = timestamp without time zone,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (timestamp without time zone, timestamp without time zone) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.date_ne_timestamp,
+    LEFTARG = date,
+    RIGHTARG = timestamp without time zone,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (date, timestamp without time zone) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.date_ne_timestamptz,
+    LEFTARG = date,
+    RIGHTARG = timestamp with time zone,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (date, timestamp with time zone) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.timestamp_ne_date,
+    LEFTARG = timestamp without time zone,
+    RIGHTARG = date,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (timestamp without time zone, date) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.timestamptz_ne_date,
+    LEFTARG = timestamp with time zone,
+    RIGHTARG = date,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (timestamp with time zone, date) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.timestamp_ne_timestamptz,
+    LEFTARG = timestamp without time zone,
+    RIGHTARG = timestamp with time zone,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (timestamp without time zone, timestamp with time zone) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.timestamptz_ne_timestamp,
+    LEFTARG = timestamp with time zone,
+    RIGHTARG = timestamp without time zone,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (timestamp with time zone, timestamp without time zone) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.uuid_ne,
+    LEFTARG = uuid,
+    RIGHTARG = uuid,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (uuid, uuid) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.record_ne,
+    LEFTARG = record,
+    RIGHTARG = record,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (record, record) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.enum_ne,
+    LEFTARG = anyenum,
+    RIGHTARG = anyenum,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (anyenum, anyenum) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.tsvector_ne,
+    LEFTARG = tsvector,
+    RIGHTARG = tsvector,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (tsvector, tsvector) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.tsquery_ne,
+    LEFTARG = tsquery,
+    RIGHTARG = tsquery,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (tsquery, tsquery) IS 'not equal';
+
+CREATE OPERATOR db2.^= (
+    PROCEDURE = pg_catalog.range_ne,
+    LEFTARG = anyrange,
+    RIGHTARG = anyrange,
+    COMMUTATOR = ^=,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR db2.^= (anyrange, anyrange) IS 'not equal';
+
+RESET search_path;

--- a/db2fce.control
+++ b/db2fce.control
@@ -1,5 +1,5 @@
 # DB2 fce extension
 comment = 'DB2 compatibility environment for PostgreSQL'
-default_version = '0.0.15'
+default_version = '0.0.16'
 module_pathname = '$libdir/db2fce'
 relocatable = false

--- a/db2fce.sql
+++ b/db2fce.sql
@@ -592,7 +592,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = integer,
     RIGHTARG = bigint,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -603,7 +602,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = boolean,
     RIGHTARG = boolean,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -614,7 +612,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = tid,
     RIGHTARG = tid,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -625,7 +622,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = bigint,
     RIGHTARG = bigint,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -636,7 +632,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = bigint,
     RIGHTARG = integer,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -647,7 +642,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = integer,
     RIGHTARG = integer,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -658,7 +652,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = smallint,
     RIGHTARG = smallint,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -669,7 +662,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = text,
     RIGHTARG = text,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -680,7 +672,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = smallint,
     RIGHTARG = integer,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -691,7 +682,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = integer,
     RIGHTARG = smallint,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -702,7 +692,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = oid,
     RIGHTARG = oid,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -713,7 +702,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = real,
     RIGHTARG = real,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -724,7 +712,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = "char",
     RIGHTARG = "char",
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -735,7 +722,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = name,
     RIGHTARG = name,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -746,7 +732,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = oidvector,
     RIGHTARG = oidvector,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -757,7 +742,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = double precision,
     RIGHTARG = double precision,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -779,7 +763,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = money,
     RIGHTARG = money,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -790,7 +773,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = character,
     RIGHTARG = character,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -801,7 +783,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = anyarray,
     RIGHTARG = anyarray,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -812,7 +793,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = date,
     RIGHTARG = date,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -823,7 +803,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = time without time zone,
     RIGHTARG = time without time zone,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -834,7 +813,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = real,
     RIGHTARG = double precision,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -845,7 +823,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = double precision,
     RIGHTARG = real,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -856,7 +833,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = inet,
     RIGHTARG = inet,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -867,7 +843,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = macaddr,
     RIGHTARG = macaddr,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -878,7 +853,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = timestamp with time zone,
     RIGHTARG = timestamp with time zone,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -889,7 +863,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = interval,
     RIGHTARG = interval,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -900,7 +873,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = circle,
     RIGHTARG = circle,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -911,7 +883,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = time with time zone,
     RIGHTARG = time with time zone,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -922,7 +893,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = lseg,
     RIGHTARG = lseg,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -933,7 +903,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = numeric,
     RIGHTARG = numeric,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -944,7 +913,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = bit,
     RIGHTARG = bit,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -955,7 +923,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = bit varying,
     RIGHTARG = bit varying,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -966,7 +933,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = smallint,
     RIGHTARG = bigint,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -977,7 +943,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = bigint,
     RIGHTARG = smallint,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -988,7 +953,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = bytea,
     RIGHTARG = bytea,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -999,7 +963,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = timestamp without time zone,
     RIGHTARG = timestamp without time zone,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -1010,7 +973,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = date,
     RIGHTARG = timestamp without time zone,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -1021,7 +983,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = date,
     RIGHTARG = timestamp with time zone,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -1032,7 +993,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = timestamp without time zone,
     RIGHTARG = date,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -1043,7 +1003,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = timestamp with time zone,
     RIGHTARG = date,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -1054,7 +1013,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = timestamp without time zone,
     RIGHTARG = timestamp with time zone,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -1065,7 +1023,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = timestamp with time zone,
     RIGHTARG = timestamp without time zone,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -1076,7 +1033,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = uuid,
     RIGHTARG = uuid,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -1087,7 +1043,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = record,
     RIGHTARG = record,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -1098,7 +1053,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = anyenum,
     RIGHTARG = anyenum,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -1109,7 +1063,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = tsvector,
     RIGHTARG = tsvector,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -1120,7 +1073,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = tsquery,
     RIGHTARG = tsquery,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );
@@ -1131,7 +1083,6 @@ CREATE OPERATOR db2.^= (
     LEFTARG = anyrange,
     RIGHTARG = anyrange,
     COMMUTATOR = ^=,
-    NEGATOR = =,
     RESTRICT = neqsel,
     JOIN = neqjoinsel
 );


### PR DESCRIPTION
With update support, tested on a Postgres 14 database. The resulting database was correctly updated to PG 18.

There's a possible performance regression. Newer PostgreSQL versions don't accept duplicate negators in operators. So the ^= operator needed to be changed not to have one. According to the documentation, this might lead to worse plans if the optimizer tries to negate the operator. 